### PR TITLE
Give docker push a manual trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Dockerfile
 
 on:
   push:
-    # Only run when one of these files change.
+    # Run when one of these files change.
     paths:
       - 'Dockerfile*'
       - entrypoint.sh
@@ -24,6 +24,9 @@ on:
       - .github/workflows/docker.yml
     branches:
       - main
+
+  # Run when manually triggered.
+  workflow_dispatch:
 
 env:
   IMAGE_NAME: octodns-sync
@@ -53,7 +56,7 @@ jobs:
     needs: test-build
 
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'workflow_dispatch'
 
     steps:
       - uses: actions/checkout@v2
@@ -77,8 +80,10 @@ jobs:
           # If GITHUB_REF is a branch, use the branch name.
           if [[ "${GITHUB_REF}" == "refs/heads/"* ]]; then
             VERSION=${GITHUB_REF#refs/heads/}
-            # If branchname is mater, use the latest instead.
-            [ "$VERSION" = "main" ] && VERSION=latest
+            # If branchname is main, use latest instead.
+            if [ "$VERSION" = "main" ]; then
+              VERSION=latest
+            fi
             _push_tags+=\ $IMAGE_ID:$VERSION
 
           # If GITHUB_REF looks like a version tag, use the tag name after


### PR DESCRIPTION
> Give docker push a manual trigger and finish s/master/main

It's been twitching me a bit that `git push` may result in a Docker image being pushed from this repo.

To enable manual runs I added a `workflow_dispatch` to the Docker workflow's `on`.

To let manual runs push images, I replaced the `push` trigger in `jobs.push-image.if` with `workflow_dispatch`.