### PR TITLE
Install octodns from PyPI rather than a Git clone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  # Maintain dependencies for PyPI packages
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      # Allow updates for octodns
+      - dependency-name: "octodns"
+        dependency-type: "direct"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,10 @@
 
 FROM python:3.7-slim
 
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y git=1:2.20.1-2+deb10u3 && \
-    rm -rf /tmp/* /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
+
+COPY requirements.txt /requirements.txt
 
 RUN /entrypoint.sh
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,18 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
-
-## [issue23] - Now
-
-### Added
-### Changed
 
 - Upgrade **github/octodns** from v0.9.10 to v0.9.11.
-- ([#22](https://github.com/solvaholic/octodns-sync/issues/22)) Start with the **python:3.7-slim** image rather than **python:3-slim**.
+- ([#22](https://github.com/solvaholic/octodns-sync/issues/22)) Build from the **python:3.7-slim** image rather than **python:3-slim**.
+- ([#NNN](https://github.com/solvaholic/octodns-sync/issues/NNN)) Install octodns from PyPI rather than a Git clone.
 
 ### Deprecated
 ### Removed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade **github/octodns** from v0.9.10 to v0.9.11.
 - ([#22](https://github.com/solvaholic/octodns-sync/issues/22)) Build from the **python:3.7-slim** image rather than **python:3-slim**.
-- ([#NNN](https://github.com/solvaholic/octodns-sync/issues/NNN)) Install octodns from PyPI rather than a Git clone.
+- ([#28](https://github.com/solvaholic/octodns-sync/pull/28)) Install octodns from PyPI rather than a Git clone.
 
 ### Deprecated
 ### Removed

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,15 +14,6 @@ _doit="${2}"
 # Change to config directory, so relative paths will work.
 cd "$(dirname "${_config_path}")" || echo "INFO: Cannot cd to $(dirname "${_config_path}")."
 
-# If GITHUB_WORKSPACE is set, prepend it to $1 for _config_path.
-echo "INFO: GITHUB_WORKSPACE is '${GITHUB_WORKSPACE}'."
-_config_path="${GITHUB_WORKSPACE%/}/${1:-public.yaml}"
-
-_doit="${2}"
-
-# Change to config directory, so relative paths will work.
-cd "$(dirname "${_config_path}")" || echo "INFO: Cannot cd to $(dirname "${_config_path}")."
-
 # Install octodns and dependencies.
 # (This should only run during docker build.)
 if ! command -v octodns-sync >/dev/null 2>&1; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,19 +14,20 @@ _doit="${2}"
 # Change to config directory, so relative paths will work.
 cd "$(dirname "${_config_path}")" || echo "INFO: Cannot cd to $(dirname "${_config_path}")."
 
-# Get octodns, if it's not already there.
-# (This should only run during docker build.)
-if ! git rev-parse --resolve-git-dir /octodns/.git >/dev/null 2>&1; then
-  git clone --branch v0.9.11 --depth 1 \
-  https://github.com/github/octodns.git /octodns
-fi
+# If GITHUB_WORKSPACE is set, prepend it to $1 for _config_path.
+echo "INFO: GITHUB_WORKSPACE is '${GITHUB_WORKSPACE}'."
+_config_path="${GITHUB_WORKSPACE%/}/${1:-public.yaml}"
 
-# Install /octodns, if not already there.
+_doit="${2}"
+
+# Change to config directory, so relative paths will work.
+cd "$(dirname "${_config_path}")" || echo "INFO: Cannot cd to $(dirname "${_config_path}")."
+
+# Install octodns and dependencies.
 # (This should only run during docker build.)
 if ! command -v octodns-sync >/dev/null 2>&1; then
   pip3 install --upgrade pip
-  pip3 install -r /octodns/requirements.txt
-  pip3 install /octodns
+  pip3 install -r /requirements.txt
 fi
 
 # Exit 0, if $_config_path is not readable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,27 @@
-git+http://github.com/github/octodns@v0.9.11#egg=octodns
+PyYaml==5.3.1
+azure-common==1.1.25
+azure-mgmt-dns==3.0.0
+boto3==1.15.9
+botocore==1.18.9
+dnspython==1.16.0
+docutils==0.16
+dyn==1.8.1
+edgegrid-python==1.1.1
+futures==3.2.0; python_version < '3.2'
+google-cloud-core==1.4.1
+google-cloud-dns==0.32.0
+ipaddress==1.0.23; python_version < '3.3'
+jmespath==0.10.0
+msrestazure==0.6.4
+natsort==6.2.1
+ns1-python==0.16.0
+ovh==0.5.0
+pycountry-convert==0.7.2
+pycountry==20.7.3
+python-dateutil==2.8.1
+requests==2.24.0
+s3transfer==0.3.3
+setuptools==44.1.1
+six==1.15.0
+transip==2.1.2
+octodns==0.9.11


### PR DESCRIPTION
When exploring @barnumbirr suggestion in #22 to use PyPI, I realized I'd like to log _all_ of octodns-sync dependencies in requirements.txt. That'd enable Dependabot and vulnerability scanning.

So I made the new requirements.txt like this:

```bash
_ver="0.9.11"
_url="https://raw.githubusercontent.com/octodns/octodns/v${_ver}/requirements.txt"
curl -LO "$_url"
printf "octodns==%s\n" "$_ver" >> requirements.txt
```

Building the contents that way removed this requirement:

```
git+http://github.com/github/octodns@v0.9.11#egg=octodns
```

Installing with `pip` means the image does not need Git, so that's out - which shrank the image by about 80MB 🎉 

(That's a 22% reduction, which I hope will be reflected in the the runners' `docker pull` times.)