### PR TITLE
Support multiple runs of the action in the same job

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,17 @@ Default `"v0.9.12"`.
 
 ## Outputs
 
+### plan
+
+If you have configured `plan_outputs` for **octodns**, PlanHtml or PlanMarkdown output will be written to `$GITHUB_WORKSPACE/octodns-sync.plan`.
+
+For convenience, this file is output by this action as the `plan` output if you need to use it in subsequent steps.
+
+### Log file
+
 `octodns-sync` will compare your configuration file to the configurations your providers have, and report any planned changes. The command logs this output in the workflow run log.
 
 That same output is saved to `$GITHUB_WORKSPACE/octodns-sync.log`.
-
-If you have configured `plan_outputs` for **octodns**, PlanHtml or PlanMarkdown output will be written to `$GITHUB_WORKSPACE/octodns-sync.plan`.
 
 ### Add pull request comment
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Provide a token to use, if you set add_pr_comment to Yes.'
     required: true
     default: 'Not set'
+outputs:
+  plan:
+    description: 'Planned changes, if configured in octodns'
+    value: ${{ steps.run.outputs.plan}}
 
 runs:
   using: 'composite'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,11 +3,8 @@
 
 # Exit early if octodns is already installed
 if command -v octodns-sync; then
-  # Hello reader!
-  # This works as a cheap, relatively safe way to respond to #57
-  # If you'd like to improve it, please raise an issue or PR
-  echo "FAIL: It looks like octodns is already installed."
-  exit 1
+  echo "INFO: It looks like octodns is already installed."
+  exit 0
 fi
 
 # Set some variables

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,8 +9,8 @@ _logfile="${GITHUB_WORKSPACE}/octodns-sync.log"
 _planfile="${GITHUB_WORKSPACE}/octodns-sync.plan"
 
 echo "INFO: Cleaning up plan and log files if they already exist"
-rm -f $_logfile
-rm -f $_planfile
+rm -f "$_logfile"
+rm -f "$_planfile"
 
 echo "INFO: _config_path: ${_config_path}"
 if [ "${_doit}" = "--doit" ]; then
@@ -32,7 +32,7 @@ grep --quiet --fixed-strings --invert-match \
 fi
 
 # https://github.community/t/set-output-truncates-multiline-strings/16852/4
-_plan="$(cat $_planfile)"
+_plan="$(cat "$_planfile")"
 _plan="${_plan//'%'/'%25'}"
 _plan="${_plan//$'\n'/'%0A'}"
 _plan="${_plan//$'\r'/'%0D'}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -8,6 +8,10 @@ _doit=$DOIT
 _logfile="${GITHUB_WORKSPACE}/octodns-sync.log"
 _planfile="${GITHUB_WORKSPACE}/octodns-sync.plan"
 
+echo "INFO: Cleaning up plan and log files if they already exist"
+rm -f $_logfile
+rm -f $_planfile
+
 echo "INFO: _config_path: ${_config_path}"
 if [ "${_doit}" = "--doit" ]; then
   script "${_logfile}" -e -c \
@@ -26,3 +30,12 @@ grep --quiet --fixed-strings --invert-match \
   echo "FAIL: octodns-sync exited with an error."
   exit 1
 fi
+
+# https://github.community/t/set-output-truncates-multiline-strings/16852/4
+_plan="$(cat $_planfile)"
+_plan="${_plan//'%'/'%25'}"
+_plan="${_plan//$'\n'/'%0A'}"
+_plan="${_plan//$'\r'/'%0D'}"
+
+# Output the plan file
+echo "::set-output name=plan::${_plan}"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD026 -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Somewhat naive attempt at allowing the action to run multiple times in the same job. By deleting the plan and log _before_ running `octodns-sync`, we make the plan file available to later steps. I also added the `plan` output to the action for more flexibility. The ability to use multiple `octodns_ref`s is not supported. The ref from the first run will be used for any subsequent runs.

Hope this adequately addresses the concerns in the issue. I'm very open to any change suggestions!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #57

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created a test [workflow](https://github.com/travislikestocode/octodns-test/blob/a4fe6bbf53123a20dca2046c5db14f395b0d3400/.github/workflows/sync.yaml) which runs the action twice in the same job, and then prints the `plan` output. The action run was [successful](https://github.com/travislikestocode/octodns-test/runs/2948427944?check_suite_focus=true)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- ~Breaking change (fix or feature that would cause existing functionality to change)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [N/A] All new and existing tests passed.
