### PR TITLE
Modify run.sh to use redirects rather than screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,13 @@ Default `"Not set"`.
 
 If you have configured `plan_outputs` for **octodns**, PlanHtml or PlanMarkdown output will be written to `$GITHUB_WORKSPACE/octodns-sync.plan`.
 
-For convenience, this file is output by this action as the `plan` output if you need to use it in subsequent steps.
+For convenience, this file is output by this action as the `plan` output so you may use it in subsequent steps.
 
-### Log file
+### log
 
-`octodns-sync` will compare your configuration file to the configurations your providers have, and report any planned changes. The command logs this output in the workflow run log.
+`octodns-sync` does not write its output to the workflow run log. Its output will be written to `$GITHUB_WORKSPACE/octodns-sync.log`.
 
-That same output is saved to `$GITHUB_WORKSPACE/octodns-sync.log`.
+For convenience, this file is output by this action as the `log` output so you may use it in subsequent steps.
 
 ### Add pull request comment
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
     required: true
     default: 'Not set'
 outputs:
+  log:
+    description: '`octodns-sync` command output'
+    value: ${{ steps.run.outputs.log}}
   plan:
     description: 'Planned changes, if configured in octodns'
     value: ${{ steps.run.outputs.plan}}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- ([#93](https://github.com/solvaholic/octodns-sync/pull/93)) Add output **log** to include output from `octodns-sync` command.
+
+### Removed
+
+- ([#93](https://github.com/solvaholic/octodns-sync/pull/93)) `octodns-sync` command output no longer appears in workflow run logs.
+
+### Fixed
+
+- ([#92](https://github.com/solvaholic/octodns-sync/issues/92)) `octodns-sync` may silently fail on some Actions runners
+
 ## [3.0.0] - 2022-06-21
 
 ### Removed

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -5,6 +5,8 @@
 # - CONFIG_PATH
 # - DOIT
 
+# shellcheck disable=SC2005,SC2086,SC2129
+
 _config_path=$CONFIG_PATH
 _doit=$DOIT
 
@@ -21,7 +23,7 @@ if [ ! "${_doit}" = "--doit" ]; then
   _doit=
 fi
 
-if ! octodns-sync --config-file="${_config_path}" "${_doit}" \
+if ! octodns-sync --config-file="${_config_path}" ${_doit} \
 1>"${_planfile}" 2>"${_logfile}"; then
   echo "FAIL: octodns-sync exited with an error."
   echo "FAIL: Here are the contents of ${_logfile}:"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -34,9 +34,9 @@ echo "INFO: octodns-sync log output has been written to ${_logfile}"
 echo "INFO: https://github.com/solvaholic/octodns-sync/issues/92"
 
 # Set the plan and log outputs
-echo 'log<<EOF' >> $GITHUB_ENV
-echo "$(cat "$_logfile")" >> $GITHUB_ENV
-echo 'EOF' >> $GITHUB_ENV
-echo 'plan<<EOF' >> $GITHUB_ENV
-echo "$(cat "$_planfile")" >> $GITHUB_ENV
-echo 'EOF' >> $GITHUB_ENV
+echo 'log<<EOF' >> $GITHUB_OUTPUT
+echo "$(cat "$_logfile")" >> $GITHUB_OUTPUT
+echo 'EOF' >> $GITHUB_OUTPUT
+echo 'plan<<EOF' >> $GITHUB_OUTPUT
+echo "$(cat "$_planfile")" >> $GITHUB_OUTPUT
+echo 'EOF' >> $GITHUB_OUTPUT

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -17,20 +17,12 @@ rm -f "$_logfile"
 rm -f "$_planfile"
 
 echo "INFO: _config_path: ${_config_path}"
-if [ "${_doit}" = "--doit" ]; then
-  script "${_logfile}" -e -c \
-  "octodns-sync --config-file=\"${_config_path}\" --doit \
-  >>\"${_planfile}\""
-else
-  script "${_logfile}" -e -c \
-  "octodns-sync --config-file=\"${_config_path}\" \
-  >>\"${_planfile}\""
+if [ ! "${_doit}" = "--doit" ]; then
+  _doit=
 fi
 
-# Exit 1 if octodns-sync exited non-zero.
-if tail --lines=1 "$_logfile" | \
-grep --quiet --fixed-strings --invert-match \
-'[COMMAND_EXIT_CODE="0"]'; then
+if ! octodns-sync --config-file="${_config_path}" "${_doit}" \
+1>"${_planfile}" 2>"${_logfile}"; then
   echo "FAIL: octodns-sync exited with an error."
   exit 1
 fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -33,16 +33,10 @@ fi
 echo "INFO: octodns-sync log output has been written to ${_logfile}"
 echo "INFO: https://github.com/solvaholic/octodns-sync/issues/92"
 
-# https://github.community/t/set-output-truncates-multiline-strings/16852/4
-_log="$(cat "$_logfile")"
-_log="${_log//'%'/'%25'}"
-_log="${_log//$'\n'/'%0A'}"
-_log="${_log//$'\r'/'%0D'}"
-_plan="$(cat "$_planfile")"
-_plan="${_plan//'%'/'%25'}"
-_plan="${_plan//$'\n'/'%0A'}"
-_plan="${_plan//$'\r'/'%0D'}"
-
-# Output the plan and log
-echo "::set-output name=log::${_log}"
-echo "::set-output name=plan::${_plan}"
+# Set the plan and log outputs
+echo 'log<<EOF' >> $GITHUB_ENV
+cat "$_logfile" >> $GITHUB_ENV
+echo 'EOF' >> $GITHUB_ENV
+echo 'plan<<EOF' >> $GITHUB_ENV
+cat "$_planfile" >> $GITHUB_ENV
+echo 'EOF' >> $GITHUB_ENV

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -24,8 +24,14 @@ fi
 if ! octodns-sync --config-file="${_config_path}" "${_doit}" \
 1>"${_planfile}" 2>"${_logfile}"; then
   echo "FAIL: octodns-sync exited with an error."
+  echo "FAIL: Here are the contents of ${_logfile}:"
+  cat "${_logfile}"
   exit 1
 fi
+
+# Acknowledge that the log output went away; Link to issue
+echo "INFO: octodns-sync log output has been written to ${_logfile}"
+echo "INFO: https://github.com/solvaholic/octodns-sync/issues/92"
 
 # https://github.community/t/set-output-truncates-multiline-strings/16852/4
 _plan="$(cat "$_planfile")"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -35,8 +35,8 @@ echo "INFO: https://github.com/solvaholic/octodns-sync/issues/92"
 
 # Set the plan and log outputs
 echo 'log<<EOF' >> $GITHUB_ENV
-cat "$_logfile" >> $GITHUB_ENV
+echo "$(cat "$_logfile")" >> $GITHUB_ENV
 echo 'EOF' >> $GITHUB_ENV
 echo 'plan<<EOF' >> $GITHUB_ENV
-cat "$_planfile" >> $GITHUB_ENV
+echo "$(cat "$_planfile")" >> $GITHUB_ENV
 echo 'EOF' >> $GITHUB_ENV

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -34,10 +34,15 @@ echo "INFO: octodns-sync log output has been written to ${_logfile}"
 echo "INFO: https://github.com/solvaholic/octodns-sync/issues/92"
 
 # https://github.community/t/set-output-truncates-multiline-strings/16852/4
+_log="$(cat "$_logfile")"
+_log="${_log//'%'/'%25'}"
+_log="${_log//$'\n'/'%0A'}"
+_log="${_log//$'\r'/'%0D'}"
 _plan="$(cat "$_planfile")"
 _plan="${_plan//'%'/'%25'}"
 _plan="${_plan//$'\n'/'%0A'}"
 _plan="${_plan//$'\r'/'%0D'}"
 
-# Output the plan file
+# Output the plan and log
+echo "::set-output name=log::${_log}"
 echo "::set-output name=plan::${_plan}"


### PR DESCRIPTION
Modify run.sh to use redirects, rather than screen, to create plan and log files.

<!-- markdownlint-disable MD041 MD026 -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently **run.sh** relies on `screen` to write command exit status in its output file. This pull request replaces that with shell redirects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`screen` on a given Actions runner may not write command exit status in its output file.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #92 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested the redirects manually, locally, running `octodns sync` in shells of Docker containers; Pushed the code to **issue92** branch and ran it in triggered workflows using **solvaholic/octodns-sync@issue92**.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See also https://github.com/solvaholic/octodns-sync/issues/92#issuecomment-1273571091

## To-Do List
<!--- Have other context to add? Screenshots or console output? Include them here. -->
- [x] Resolve the issue reported in #92
  _Redirect output rather than capture it with `screen`_
- [x] Mention #92 on stdout, for folks expecting to see log output
  _Echo comments to stdout, link to the issue_
- [x] Expose `octodns sync` output as an Action output
  _Set it in script and update action.yml and README.md_
- [x] Update CHANGELOG.md
  _Add a new entry for this pull request, #93_
- [x] Raise #94 to handle [deprecation of **set-output**](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
