### PR TITLE
Use `github.event.pull_request.comments_url`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
       env:
         ADD_PR_COMMENT: ${{ inputs.add_pr_comment }}
         PR_COMMENT_TOKEN: ${{ inputs.pr_comment_token }}
-        COMMENTS_URL: ${{ github.pull_request.comments_url }}
+        COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
       run: ${{ github.action_path }}/scripts/comment.sh
       shell: bash
       working-directory: ${{ github.workspace }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- ([#92](https://github.com/solvaholic/octodns-sync/issues/92)) `octodns-sync` may silently fail on some Actions runners
+- ([#92](https://github.com/solvaholic/octodns-sync/issues/92)) `octodns-sync` may silently fail on some Actions runners.
+- ([#94](https://github.com/solvaholic/octodns-sync/issues/94)) `set-output` is being deprecated.
+- ([#97](https://github.com/solvaholic/octodns-sync/issues/97)) `COMMENTS_URL` is not set correctly.
 
 ## [3.0.0] - 2022-06-21
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD026 -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Not sure when this change happened, but in order to get the correct `comments_url` from GitHub, the proper environment name is `github.event.pull_request.comments_url` (note the extra `.event`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This bugfix ensures that for a `pull_request` target, a comment is added again if `add_pr_comment` is set to `Yet` and `pr_comment_token` is set.

Without this fix the Action log wil mention something like this:
```
INFO: $ADD_PR_COMMENT is 'Yes' and $PR_COMMENT_TOKEN is set.
SKIP: $COMMENTS_URL is not set.
Was this workflow run triggered from a pull request?
```

With this fix, the expected result of a PR comment is achieved:
```
INFO: $ADD_PR_COMMENT is 'Yes' and $PR_COMMENT_TOKEN is set.
<Response [201]>
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've tested this locally, and you can also test it by using `uses: jasperroel/octodns-sync@main` instead of `uses: solvaholic/octodns-sync@main`

