### PR TITLE
Added action input to run octodns-sync in force mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Really do it? Set "--doit" to do it; Any other string to not do it.
 
 Default `""` (empty string).
 
+### `force`
+
+Run octodns-sync in force mode? Set "Yes" to do it.
+
+Default `"No"`.
+
 ### `add_pr_comment`
 
 Add plan as a comment, when triggered by a pull request? Set "Yes" to do it.

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,10 @@
 name: 'octodns-sync'
 description: 'Run octodns/octodns to deploy your DNS config to any cloud.'
 inputs:
+  force:
+    description: 'Run octodns in force mode?'
+    required: true
+    default: 'No'
   add_pr_comment:
     description: 'Add plan as a comment, when triggered by a pull request?'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -3,10 +3,6 @@
 name: 'octodns-sync'
 description: 'Run octodns/octodns to deploy your DNS config to any cloud.'
 inputs:
-  force:
-    description: 'Run octodns in force mode?'
-    required: true
-    default: 'No'
   add_pr_comment:
     description: 'Add plan as a comment, when triggered by a pull request?'
     required: true
@@ -21,6 +17,10 @@ inputs:
                   not do it.'
     required: false
     default: ''
+  force:
+    description: 'Run octodns in force mode?'
+    required: false
+    default: 'No'
   pr_comment_token:
     description: 'Provide a token to use, if you set add_pr_comment to Yes.'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,7 @@ runs:
       env:
         CONFIG_PATH: ${{ inputs.config_path }}
         DOIT: ${{ inputs.doit }}
+        FORCE: ${{ inputs.force }}
       run: ${{ github.action_path }}/scripts/run.sh
       shell: bash
       working-directory: ${{ github.workspace }}

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: ''
   force:
-    description: 'Run octodns in force mode?'
+    description: 'Run octodns-sync in force mode?'
     required: false
     default: 'No'
   pr_comment_token:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - ([#93](https://github.com/solvaholic/octodns-sync/pull/93)) Add output **log** to include output from `octodns-sync` command.
+- ([#98](https://github.com/solvaholic/octodns-sync/pull/98)) Integrate octodns' force flag.
 
 ### Removed
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,6 +9,7 @@
 
 _config_path=$CONFIG_PATH
 _doit=$DOIT
+_force=$FORCE
 
 # Run octodns-sync.
 _logfile="${GITHUB_WORKSPACE}/octodns-sync.log"
@@ -22,8 +23,11 @@ echo "INFO: _config_path: ${_config_path}"
 if [ ! "${_doit}" = "--doit" ]; then
   _doit=
 fi
+if [ ! "${_force}" = "Yes" ]; then
+  _force=
+fi
 
-if ! octodns-sync --config-file="${_config_path}" ${_doit} \
+if ! octodns-sync --config-file="${_config_path}" ${_doit} ${_force} \
 1>"${_planfile}" 2>"${_logfile}"; then
   echo "FAIL: octodns-sync exited with an error."
   echo "FAIL: Here are the contents of ${_logfile}:"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -23,7 +23,9 @@ echo "INFO: _config_path: ${_config_path}"
 if [ ! "${_doit}" = "--doit" ]; then
   _doit=
 fi
-if [ ! "${_force}" = "Yes" ]; then
+if [ "${_force}" = "Yes" ]; then
+  _force="--force"
+else
   _force=
 fi
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -23,7 +23,9 @@ echo "INFO: _config_path: ${_config_path}"
 if [ ! "${_doit}" = "--doit" ]; then
   _doit=
 fi
+
 if [ "${_force}" = "Yes" ]; then
+  echo "INFO: Running octodns-sync in force-mode"
   _force="--force"
 else
   _force=


### PR DESCRIPTION
## Description
Adds `force` as action input to run octodns in force mode ( #98).

## Motivation and Context
See #98 

## How Has This Been Tested?
Manual tests if major tests fail without it and work with setting it to `Yes`.
